### PR TITLE
declare compatibility

### DIFF
--- a/woocommerce-order-paid-webhook.php
+++ b/woocommerce-order-paid-webhook.php
@@ -180,3 +180,10 @@ WOPW::get_instance();
 function WOPW() { // phpcs:ignore
 	return WOPW::get_instance();
 }
+
+//Declare compatibility HPOS
+add_action( 'before_woocommerce_init', function() {
+	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+	}
+} );


### PR DESCRIPTION
niklashogefjord
  [7:35 AM](https://krokedil.slack.com/archives/CQQCT3RM5/p1698647759746889)
WooCommerce Order paid webhook hanterar ingen metadata så det ska räcka att deklarera stöd där.